### PR TITLE
Corrections

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -159,7 +159,7 @@ Quelle que soit la forme du `reset` que vous invoquez pour un _commit_, ce sera 
 Avec `reset --soft`, il n'ira pas plus loin.
 
 Maintenant, arrêtez-vous une seconde et regardez le diagramme ci-dessus pour comprendre ce qu'il s'est passé : en essence, il a défait ce que la dernière commande `git commit` a créé.
-Quand vous lancez `git commit`, Git crée un nouvel objet _commit_ and déplace la branche pointée par HEAD dessus.
+Quand vous lancez `git commit`, Git crée un nouvel objet _commit_ et déplace la branche pointée par HEAD dessus.
 Quand vous faites un `reset`  sur `HEAD~` (le parent de `HEAD`), vous replacez la branche où elle était, sans changer ni l'index ni la copie de travail.
 Vous pourriez maintenant mettre à jour l'index et relancer `git commit` pour accomplir ce que `git commit --amend` aurait fait (voir <<_git_amend>>).
 

--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -160,7 +160,7 @@ Avec `reset --soft`, il n'ira pas plus loin.
 
 Maintenant, arrêtez-vous une seconde et regardez le diagramme ci-dessus pour comprendre ce qu'il s'est passé : en essence, il a défait ce que la dernière commande `git commit` a créé.
 Quand vous lancez `git commit`, Git crée un nouvel objet _commit_ et déplace la branche pointée par HEAD dessus.
-Quand vous faites un `reset`  sur `HEAD~` (le parent de `HEAD`), vous replacez la branche où elle était, sans changer ni l'index ni la copie de travail.
+Quand vous faites un `reset` sur `HEAD~` (le parent de `HEAD`), vous replacez la branche où elle était, sans changer ni l'index ni la copie de travail.
 Vous pourriez maintenant mettre à jour l'index et relancer `git commit` pour accomplir ce que `git commit --amend` aurait fait (voir <<_git_amend>>).
 
 ===== Étape 2 : Mise à jour de l'index (--mixed)

--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -165,7 +165,7 @@ Vous pourriez maintenant mettre à jour l'index et relancer `git commit` pour ac
 
 ===== Étape 2 : Mise à jour de l'index (--mixed)
 
-Notez que si vous lancez `git status` maintenant, vous verrez en vert la différence entre l'index et la nouvelle HEAD.
+Notez que si vous lancez `git status` maintenant, vous verrez en vert la différence entre l'index et le nouveau HEAD.
 
 La chose suivante que `reset` réalise est de mettre à jour l'index avec le contenu de l'instantané pointé par HEAD.
 

--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -155,7 +155,7 @@ Ceci signifie que si HEAD est pointé sur la branche `master` (par exemple, si v
 
 image::images/reset-soft.png[]
 
-Quelle que soit la forme du `reset` que vous invoquez pour un _commit_, ce sera toujours le première chose qu'il tentera de faire.
+Quelle que soit la forme du `reset` que vous invoquez pour un _commit_, ce sera toujours la première chose qu'il tentera de faire.
 Avec `reset --soft`, il n'ira pas plus loin.
 
 Maintenant, arrêtez-vous une seconde et regardez le diagramme ci-dessus pour comprendre ce qu'il s'est passé : en essence, il a défait ce que la dernière commande `git commit` a créé.
@@ -203,7 +203,7 @@ La commande `reset` remplace ces trois arbres dans un ordre spécifique, s'arrê
 
 Tout cela couvre le comportement de `reset` dans sa forme de base, mais vous pouvez aussi lui fournir un chemin sur lequel agir.
 Si vous spécifiez un chemin, `reset` sautera la première étape et limitera la suite de ses actions à un fichier spécifique ou à un ensemble de fichiers.
-Cela fait sens, en fait, HEAD n'est rien de plus qu'un pointeur et vous ne pouvez pas pointer sur une partie d'un _commit_ et une partie d'un autre.
+Cela fait sens ; en fait, HEAD n'est rien de plus qu'un pointeur et vous ne pouvez pas pointer sur une partie d'un _commit_ et une partie d'un autre.
 Mais l'index et le répertoire de travail _peuvent_ être partiellement mis à jour, donc `reset` continue avec les étapes 2 et 3.
 
 Donc, supposons que vous lancez `git reset file.txt`.
@@ -241,7 +241,7 @@ Voyons comment faire quelque chose d'intéressant avec ce tout nouveau pouvoir -
 Supposons que vous avez une série de _commits_ contenant des messages tels que « oups », « en chantier » ou « ajout d'un fichier manquant ».
 Vous pouvez utiliser `reset` pour les écraser tous rapidement et facilement en une seule validation qui vous donne l'air vraiment intelligent (<<_squashing>> explique un autre moyen de faire pareil, mais dans cet exemple, c'est plus simple de faire un `reset`).
 
-Disons que vous avez un projet où le premier _commit_ contient un fichier, le second _commit_ a ajouté un nouveau fichier et à modifié le premier, et le troisième à remodifié le premier fichier.
+Disons que vous avez un projet où le premier _commit_ contient un fichier, le second _commit_ a ajouté un nouveau fichier et a modifié le premier, et le troisième a remodifié le premier fichier.
 Le second _commit_ était encore en chantier et vous souhaitez le faire disparaître.
 
 image::images/reset-squash-r1.png[]
@@ -293,7 +293,7 @@ De même que `git reset` et `git add`, `checkout` accepte une option `--patch` p
 
 ==== Résumé
 
-J'espère qu'à présent, vous comprenez mieux et vous sentez plus à l'aise avec la commande `reset`, même si vous pouvez vous sentir encore un peu confus sur ce qui le différencie exactement de `checkout` et avoir du mal à vous souvenir de toutes les règles de ses différentes invocations.
+J'espère qu'à présent vous comprenez mieux et vous sentez plus à l'aise avec la commande `reset`, même si vous pouvez vous sentir encore un peu confus sur ce qui la différencie exactement de `checkout` et avoir du mal à vous souvenir de toutes les règles de ses différentes invocations.
 
 Voici un aide-mémoire sur ce que chaque commande affecte dans chaque arborescence.
 La colonne « HEAD » contient « RÉF » si cette commande déplace la référence (branche) pointée par HEAD, et « HEAD » si elle déplace HEAD lui-même.


### PR DESCRIPTION
Bonjour,

Voici un lot de corrections pour le fichier book/07-git-tools/sections/reset.asc.
Je les ai séparées dans différents _commits_ parce que les corrections sont de différentes natures.

En particulier, pour le _commit_ 732e82a, on voit que dans l'étape 1 décrite plus haut dans le texte, HEAD est considéré comme masculin :
> [...] HEAD lui-même [...]
> [...] HEAD est pointé [...]

Donc j'ai accordé nouveau au masculin pour que ça reste homogène.