### PR TITLE
git shell

### DIFF
--- a/book/04-git-server/sections/setting-up-server.asc
+++ b/book/04-git-server/sections/setting-up-server.asc
@@ -94,11 +94,11 @@ $ which git-shell   # s'assurer que git-shell est installé sur le système
 $ sudo vim /etc/shells  # et ajouter le chemin complet vers git-shell
 ----
 
-Maintenant, vous pouvez éditer le shell de l'utilisateur en utilisant `chsh <utilisateur>` :
+Maintenant, vous pouvez éditer le shell de l'utilisateur en utilisant `chsh <utilisateur> -s <shell>` :
 
 [source,console]
 ----
-$ sudo chsh git  # saisir le chemin vers git-shell, souvent : /usr/bin/git-shell
+$ sudo chsh git -s `which git-shell`
 ----
 
 À présent, l'utilisateur 'git' ne peut plus utiliser la connexion SSH que pour pousser et tirer sur des dépôts Git, il ne peut plus ouvrir un shell.


### PR DESCRIPTION
Bonjour,

voici la correction portée de progit/progit2#734.

Il s'agit d'utiliser le shell pour remplir automatiquement le chemin absolu de git-shell pour l'utilisateur git.