### PR TITLE
adaptation commande sed selon le système d'exploitation

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -72,8 +72,8 @@ $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
 $ sed -i '' 's/1000/3000/' blink.ino (MacOSX) <3>
-#Si vous êtes sur un système Linux, faites plutôt ceci :
-$ #sed -i 's/1000/3000/' blink.ino <3>
+# Si vous êtes sur un système Linux, faites plutôt ceci :
+# $ sed -i 's/1000/3000/' blink.ino <3>
 
 $ git diff --word-diff <4>
 diff --git a/blink.ino b/blink.ino

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -71,7 +71,9 @@ $ cd blink
 $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
-$ sed -i '' 's/1000/3000/' blink.ino <3>
+$ sed -i '' 's/1000/3000/' blink.ino (MacOSX) <3>
+#Si vous êtes sur un système Linux, faites plutôt ceci :
+$ #sed -i 's/1000/3000/' blink.ino <3>
 
 $ git diff --word-diff <4>
 diff --git a/blink.ino b/blink.ino

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -71,7 +71,7 @@ $ cd blink
 $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
-$ sed -i '' 's/1000/3000/' blink.ino (MacOSX) <3>
+$ sed -i '' 's/1000/3000/' blink.ino # (MacOSX) <3>
 # Si vous êtes sur un système Linux, faites plutôt ceci :
 # $ sed -i 's/1000/3000/' blink.ino <3>
 


### PR DESCRIPTION
Bonjour,

cette modification est le résultat des deux requêtes de tirage successives suivantes : progit/progit2#724 et progit/progit2#743.

En résumé, les paramètres passés à la commande sed ne sont pas les mêmes selon qu'on est sous MacOSX ou sous Linux.

Adrien Ollier