### PR TITLE
corrigé la représentation de la combinaison de touches "alt + →"

### DIFF
--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -13,7 +13,7 @@ Celle-ci est heureusement très bien documentée et supportée.
 
 GitLab peut s'installer de différentes manières.
 Pour obtenir rapidement quelque chose qui tourne, vous pouvez télécharger une image de machine virtuelle ou un installateur rapide depuis https://bitnami.com/stack/gitlab[], puis configurer plus finement selon vos besoins.(((bitnami)))
-Une touche particulière incluse par Bitnami concerne l'écran d'identification (accessible via alt-&rarr;) qui vous indique l'adresse IP, l'utilisateur et le mot de passe par défaut de l'instance GitLab installée.
+Une touche particulière incluse par Bitnami concerne l'écran d'identification (accessible via alt+→) qui vous indique l'adresse IP, l'utilisateur et le mot de passe par défaut de l'instance GitLab installée.
 
 [[bitnami]]
 .L'écran d’identification de la machine virtuelle du GitLab de Bitnami.

--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -13,7 +13,7 @@ Celle-ci est heureusement très bien documentée et supportée.
 
 GitLab peut s'installer de différentes manières.
 Pour obtenir rapidement quelque chose qui tourne, vous pouvez télécharger une image de machine virtuelle ou un installateur rapide depuis https://bitnami.com/stack/gitlab[], puis configurer plus finement selon vos besoins.(((bitnami)))
-Une touche particulière incluse par Bitnami concerne l'écran d'identification (accessible via alt+→) qui vous indique l'adresse IP, l'utilisateur et le mot de passe par défaut de l'instance GitLab installée.
+Une touche particulière incluse par Bitnami concerne l'écran d'identification (accessible via `alt + →`) qui vous indique l'adresse IP, l'utilisateur et le mot de passe par défaut de l'instance GitLab installée.
 
 [[bitnami]]
 .L'écran d’identification de la machine virtuelle du GitLab de Bitnami.


### PR DESCRIPTION
Bonjour,

suite à des problèmes constatés dans la version PDF de progit, j'ai fait les modifications suivantes :

* remplacé le '-' séparateur par un '+'
* remplacé l'entité xml représentant la flèche droite par le symbole de la flèche droite ('→')

Les apostrophes s'affichent correctement ainsi que le lien vers bitnami mais la flèche droite n'apparaît toujours pas chez moi.

Adrien Ollier