### PR TITLE
remplacé la référence du dépôt SVN d'exemple

### DIFF
--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -29,7 +29,7 @@ Si vous travaillez avec une équipe dont certains membres utilisent SVN et d'aut
 ===== Installation
 
 Pour montrer cette fonctionnalité, il faut un serveur SVN sur lequel vous avez des droits en écriture.
-Pour copier ces exemples, faites une copie inscriptible de mon dépôt de test.
+Pour copier ces exemples, vous avez besoin de faire une copie inscriptible d'un dépôt SVN de test accessible.
 Dans cette optique, vous pouvez utiliser un outil appelé `svnsync` qui est livré avec les versions les plus récentes de Subversion — il devrait être distribué avec les versions à partir de 1.4.
 
 En préparation, créez un nouveau dépôt local Subversion :

--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -31,7 +31,6 @@ Si vous travaillez avec une équipe dont certains membres utilisent SVN et d'aut
 Pour montrer cette fonctionnalité, il faut un serveur SVN sur lequel vous avez des droits en écriture.
 Pour copier ces exemples, faites une copie inscriptible de mon dépôt de test.
 Dans cette optique, vous pouvez utiliser un outil appelé `svnsync` qui est livré avec les versions les plus récentes de Subversion — il devrait être distribué avec les versions à partir de 1.4.
-Pour ces tests, j'ai créé sur Google code un nouveau dépôt Subversion qui était une copie partielle du projet `protobuf` qui est un outil qui encode les données structurées pour une transmission par réseau.
 
 En préparation, créez un nouveau dépôt local Subversion :
 
@@ -55,7 +54,7 @@ Vous pouvez à présent synchroniser ce projet sur votre machine locale en lanç
 
 [source,console]
 ----
-$ svnsync init file:///tmp/test-svn http://progit-example.googlecode.com/svn/
+$ svnsync init file:///tmp/test-svn http://votre-serveur-svn.org/svn/
 ----
 
 Cela initialise les propriétés nécessaires à la synchronisation.


### PR DESCRIPTION
Le domaine googlecode.com n'existe plus.
Le dépôt SVN de googlecode.com n'a pas été recréé ailleurs.

Cette modification correspond à progit/progit2#653 qui corrige progit/progit2#631.