### PR TITLE
génération manuelle du livre dans les différents formats

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -16,23 +16,12 @@ Ensuite, il suffit de lancer une requête de tirage pour nous avertir que les mo
 
 == Comment générer le livre
 
-Il y a deux façons de générer le livre aux formats PDF, e-pub, mobi et HTML.
+Vous pouvez générer les différentes versions du livre manuellement avec Asciidoctor.
+Pour cela, vous devez installer les paquets `ruby`, `rubygems`, `rubygem-asciidoctor` et `ruby-devel` s'ils ne sont pas déjà installés.
 
-La façon la plus facile est tout simplement de nous laisser le faire. Un robot est toujours à l'écoute des nouveautés sur la branche principale et le construit automatiquement pour tout le monde.
-
-Vous pouvez trouver la dernière publication à l'adresse http://git-scm.com/book/fr/v2[]. Vous trouverez plus d'informations à ce sujet sur le site https://progit.org[] et vous pouvez voir les publications successives à l'adresse https://progit.org/translations/lang/fr[].
-
-L'autre façon de générer les différentes versions du livre est de le faire manuellement avec Asciidoctor. Pour cela, vous devez installer les paquets `ruby`, `rubygems`, `rubygem-asciidoctor` et `ruby-devel` s'ils ne sont pas déjà installés.
-
-Vous ne lancerez la commande suivante qu'une seule fois :
-
+Vous pouvez générer le livre aux formats PDF, e-pub, mobi et HTML avec les commandes suivantes :
 ----
 $ bundle install
-----
-
-Ensuite, lorsque de nouvelles versions sont publiées, vous générerez le livre aux formats PDF, e-pub, mobi et HTML avec la commande suivante :
-
-----
 $ bundle exec rake book:build
 Converting to HTML...
  -- HTML output at progit.html
@@ -42,6 +31,24 @@ Converting to Mobi (kf8)...
  -- Mobi output at progit.mobi
 Converting to PDF...
  -- PDF output at progit.pdf
+----
+
+Une alternative à l'appel de la commande `bundle` est d'appeler directement la commande `asciidoctor`.
+Si c'est la première fois que vous construisez le livre, il faut créer le dossier _images_ et le remplir.
+Faites ce qui suit une seule fois :
+[source,console]
+----
+$ mkdir images
+$ cp book/*/images/* images/
+----
+
+Vous pouvez ensuite créer le livre.
+Utilisez les commandes suivantes :
+[source,console]
+----
+$ asciidoctor-pdf progit.asc
+$ asciidoctor-epub3 progit.asc
+$ asciidoctor-epub3 -a ebook-format=kf8 progit.asc
 ----
 
 Cela utilise les projets `asciidoctor`, `asciidoctor-pdf` et `asciidoctor-epub`.

--- a/README.asc
+++ b/README.asc
@@ -51,6 +51,9 @@ $ asciidoctor-epub3 progit.asc
 $ asciidoctor-epub3 -a ebook-format=kf8 progit.asc
 ----
 
+La conversion des fichiers asciidoctor vers le format epub3 requiert une structure particulière qui n'est pas compatible avec les autres formats.
+En conséquence, les liens internes au fichier au format epub3 ne fonctionnent pas.
+
 Cela utilise les projets `asciidoctor`, `asciidoctor-pdf` et `asciidoctor-epub`.
 
 Pour plus d'informations, veuillez vous référer à `generer_livre.asc`.


### PR DESCRIPTION
Bonjour,

La mise à jour de README.asc est une mise à niveau par rapport à la version anglaise.
La mention du robot qui générait automatiquement le livre dans les différents formats ainsi que la référence à progit.org ont été supprimées et on indique comment générer le livre sans la commande `bundle`.

Adrien Ollier