### PR TITLE
patch 9e5e64a => 9e5e6a4

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -151,7 +151,7 @@ Il réalise jusqu'à trois opérations basiques.
 La première chose que `reset` va faire consiste à déplacer ce qui est pointé par HEAD.
 Ce n'est pas la même chose que changer HEAD lui-même (ce que fait `checkout`).
 `reset` déplace la branche que HEAD pointe.
-Ceci signifie que si HEAD est pointé sur la branche `master` (par exemple, si vous êtes sur la branche `master`), lancer `git reset 9e5e64a` va commencer par faire pointer `master` sur `9e5e64a`.
+Ceci signifie que si HEAD est pointé sur la branche `master` (par exemple, si vous êtes sur la branche `master`), lancer `git reset 9e5e6a4` va commencer par faire pointer `master` sur `9e5e6a4`.
 
 image::images/reset-soft.png[]
 


### PR DESCRIPTION
Correction d'une petite coquille entre le nom de l'objet de l'image et celle du texte