### PR TITLE
prise en compte de la syntaxe de .bzrignore

### DIFF
--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -76,11 +76,28 @@ $ git fetch
 
 ===== Ignorer ce qui est ignoré avec .bzrignore
 
-Comme le format du fichier `.bzrignore` est complètement compatible avec celui de `.gitignore`, et comme vous ne devriez pas créer de fichier `.gitignore` dans votre dépôt, il suffit de créer un lien symbolique vers `.bzrignore` pour que les potentiels changements de `.bzrignore` soient pris en compte :
-[source,console]
-----
-$ ln -s .bzrignore .git/info/exclude
-----
+Puisque vous travaillez sur un projet géré sous Bazaar, vous ne devriez pas créer de fichier `.gitignore` car vous pourriez le mettre accidentellement en gestion de version et les autres personnes travaillant sous Bazaar en seraient dérangées.
+La solution est de créer le fichier `.git/info/exclude`, soit en tant que lien symbolique, soit en tant que véritable fichier.
+Nous allons voir plus loin comment trancher cette question.
+
+Bazaar utilise le même modèle que Git pour ignorer les fichiers, mais possède en plus deux particularités qui n'ont pas d'équivalent dans Git.
+La description complète se trouve dans http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/ignore-help.html[la documentation].
+Les deux particularités sont :
+
+1. le "!!" en début de chaîne de caractères qui prévaut sur le "!" en début de chaîne, ce qui permet d'ignorer des fichiers qui auraient été inclus avec "!"
+2. les chaînes de caractères commençant par "RE:".
+Ce qui suit "RE:" est une http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/patterns-help.html[expression rationnelle].
+Git ne permet pas d'utiliser des expressions rationnelles, seulement les globs shell.
+
+Par conséquent, il y a deux situations différentes à envisager :
+
+1. Si le fichier `.bzrignore` ne contient aucun de ces deux préfixes particuliers, alors vous pouvez simplement faire un lien symbolique vers celui-ci dans le dépôt.
+2. Sinon, vous devez créer le fichier `.git/info/exclude` et l'adapter pour ignorer exactement les mêmes fichiers que dans `.bzrignore`.
+
+Quel que soit le cas de figure, vous devrez rester vigilant aux modifications du fichier `.bzrignore` pour faire en sorte que le fichier `.git/info/exclude` reflète toujours `.bzrignore`.
+En effet, si le fichier `.bzrignore` venait à changer et comporter une ou plusieurs lignes commençant par "!!" ou "RE:", Git ne pouvant interpréter ces lignes, il vous faudra adapter le fichier `.git/info/exclude` pour ignorer les mêmes fichiers que ceux ignorés avec `.bzrignore`.
+De surcroît, si le fichier `.git/info/exclude` était un lien symbolique vers `.bzrignore`, il vous faudra alors d'abord détruire le lien symbolique, copier le fichier `.bzrignore` dans `.git/info/exclude` puis adapter ce dernier.
+Attention toutefois à son élaboration car avec Git il est impossible de ré-inclure un fichier dont l'un des dossiers parent a été exclu.
 
 
 ===== Récupérer les changements du dépôt distant

--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -121,11 +121,14 @@ $ git reset --hard HEAD
 ===== Ignorer les fichiers qui étaient ignorés avec .bzrignore
 
 Occupons-nous maintenant des fichiers à ignorer.
-Comme le format de `.bzrignore` est le même que celui de `.gitignore`, le plus simple est de renommer votre fichier `.bzrignore`.
-Vous devrez aussi créer un _commit_ qui contient cette modification pour la migration :
+Il faut tout d'abord renommer le fichier `.bzrignore` en `.gitignore`.
+Si le fichier `.bzrignore` contient une ou des lignes commençant par "!!" ou "RE:", il vous faudra en plus le modifier et peut-être créer de multiples fichiers `.gitignore` afin d'ignorer exactement les mêmes fichiers que le permettait `.bzrignore`.
+
+Finalement, vous devrez créer un _commit_ qui contient cette modification pour la migration :
 [source,console]
 ----
 $ git mv .bzrignore .gitignore
+$ # modifier le fichier .gitignore au besoin
 $ git commit -m 'Migration de Bazaar vers Git'
 ----
 


### PR DESCRIPTION
Bazaar a une syntaxe plus étendue que Git pour ignorer certains fichiers.
Il faut donc adapter le fichier d'exclusion du dépôt Git pour prendre
en compte les éventuelles incompatibilités.