### PR TITLE
commande clone : --recursive → --recurse-submodules

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -178,11 +178,11 @@ Submodule path 'DbConnector': checked out 'c3f01dc8862123d317dd46284b05b6892c7b2
 Votre répertoire `DbConnector` est maintenant dans l'état exact dans lequel il était la dernière fois que vous avez validé.
 
 Il existe une autre manière plus simple d'arriver au même résultat.
-Si vous passez l'option `--recursive` à la commande `git clone`, celle-ci initialisera et mettra à jour automatiquement chaque sous-module du dépôt.
+Si vous passez l'option `--recurse-submodules` à la commande `git clone`, celle-ci initialisera et mettra à jour automatiquement chaque sous-module du dépôt.
 
 [source,console]
 ----
-$ git clone --recursive https://github.com/chaconinc/MainProject
+$ git clone --recurse-submodules https://github.com/chaconinc/MainProject
 Clonage dans 'MainProject'...
 remote: Counting objects: 14, done.
 remote: Compressing objects: 100% (13/13), done.

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -71,7 +71,7 @@ Dans <<_git_on_the_server>>, nous montrons l'utilisation de l'option `--bare` po
 
 Dans <<_bundling>>, nous l'utilisons pour dépaqueter un dépôt Git empaqueté.
 
-Enfin, dans <<_cloning_submodules>>, nous apprenons l'option `--recursive` pour rendre le clonage d'un dépôt avec sous-modules un peu plus simple.
+Enfin, dans <<_cloning_submodules>>, nous apprenons l'option `--recurse-submodules` pour rendre le clonage d'un dépôt avec sous-modules un peu plus simple.
 
 Bien qu'elle soit utilisée dans beaucoup d'autres endroits du livre, ceux-là sont ceux qui sont en quelque sorte uniques ou qui sont utilisés de manière un peu différente.
 


### PR DESCRIPTION
L'option '--recursive' a été remplacée à partir de la version 2.11.0 de Git.
En conformité avec progit/progit2#928.