### PR TITLE
correction installation du plugin bzr-fastimport

### DIFF
--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -32,8 +32,8 @@ $ sudo dnf install bzr-fastimport
 Si le paquet n'est pas disponible, vous pouvez l'installer en tant que plugin :
 [source,console]
 ----
-$ mkdir --parents ~/.bazaar/plugins/bzr     # crée les dossiers nécessaires aux plugins
-$ cd ~/.bazaar/plugins/bzr
+$ mkdir --parents ~/.bazaar/plugins/   # crée les dossiers nécessaires aux plugins
+$ cd ~/.bazaar/plugins/
 $ bzr branch lp:bzr-fastimport fastimport   # importe le plugin bzr-fastimport
 $ cd fastimport
 $ sudo python setup.py install --record=files.txt   # installe le plugin


### PR DESCRIPTION
Les plugins sont installés dans ~/.bazaar/plugins plutôt que dans ~/.bazaar/plugins/bzr.

voir progit/progit2#1037