### PR TITLE
correction taille des objets git

### DIFF
--- a/book/10-git-internals/sections/packfiles.asc
+++ b/book/10-git-internals/sections/packfiles.asc
@@ -122,8 +122,8 @@ Puisqu'ils n'ont été ajoutés à aucun _commit_, ils sont considérés en susp
 Les autres fichiers sont le nouveau fichier groupé et un index.
 Le fichier groupé est un fichier unique rassemblant le contenu de tous les objets venant d'être supprimés du système de fichier.
 L'index est un fichier contenant les emplacements dans le fichier groupé, pour que l'on puisse accéder rapidement à un objet particulier.
-Ce qui est vraiment bien, c'est que les objets occupaient environ 22 ko d'espace disque avant `gc` et que le nouveau fichier groupé en occupe seulement 7.
-On a réduit l'occupation du disque de ⅔ en regroupant les objets.
+Ce qui est vraiment bien, c'est que les objets occupaient environ 15 ko d'espace disque avant `gc` et que le nouveau fichier groupé en occupe seulement 7.
+On a réduit l'occupation du disque de ½ en regroupant les objets.
 
 Comment Git réalise-t-il cela ?
 Quand Git compacte des objets, il recherche les fichiers qui ont des noms et des tailles similaires, puis enregistre seulement les deltas entre une version du fichier et la suivante.


### PR DESCRIPTION
La taille des objets est bien de 15 ko : 2 objets de 22 ko compressés à environ 7 ko chacun + les objets qui occupent 925 octets ≈ 2 × 7 ko + 1 ko = 15 ko.
Le nouveau fichier groupé n'occupe que 7 ko et 7 ko ÷ 15 ko ≈ ½. Donc la taille a bien été divisée par deux environ.