### PR TITLE
Branches distantes

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -1,14 +1,14 @@
 [[s_remote_branches]]
-== Branches distantes
+== Branches de suivi à distance
 
 (((branches, distant)))(((références, distant)))
 Les références distantes sont des références (pointeurs) vers les éléments de votre dépôt distant tels que les branches, les tags, etc...
 Vous pouvez obtenir la liste complète de ces références distantes avec la commade `git ls-remote (remote)`, ou `git remote show (remote)`.
-Néanmoins, une manière plus courante consiste à tirer parti des branches distantes.
+Néanmoins, une manière plus courante consiste à tirer parti des branches de suivi à distance.
 
-Les branches distantes sont des références (des pointeurs) vers l'état des branches sur votre dépôt distant.
+Les branches de suivi à distance sont des références (des pointeurs) vers l'état des branches sur votre dépôt distant.
 Ce sont des branches locales qu'on ne peut pas modifier ; elles sont modifiées automatiquement pour vous lors de communications réseau.
-Les branches distantes agissent comme des marques-pages pour vous aider à vous souvenir de l'état des branches sur votre dépôt distant lors de votre dernière connexion.
+Les branches de suivi à distance agissent comme des marques-pages pour vous indiquer l'état des branches sur votre dépôt distant lors de votre dernière connexion.
 
 Elles prennent la forme de `(distant)/(branche)`.
 Par exemple, si vous souhaitiez visualiser l'état de votre branche `master` sur le dépôt distant `origin` lors de votre dernière communication, il vous suffirait de vérifier la branche `origin/master`.
@@ -22,7 +22,9 @@ Git crée également votre propre branche `master` qui démarre au même endroit
 [NOTE]
 .`origin` n'est pas spécial
 ====
-De la même manière que le nom de branche `master` n'a aucun sens particulier pour Git, le nom `origin` n'est pas spécial. Tandis que `master` est le nom attribué par défaut à votre branche initiale lorsque vous lancez la commande `git init` et c'est la seule raison pour laquelle ce nom est utilisé aussi largement, `origin` est le nom utilisé par défaut pour un dépôt distant lorsque vous lancez `git clone`. Si vous lancez à la place `git clone -o booyah`, votre branche distante par défaut s'appellera `booyah/master`.(((origin)))
+De la même manière que le nom de branche `master` n'a aucun sens particulier pour Git, le nom `origin` n'est pas spécial.
+Tandis que `master` est le nom attribué par défaut à votre branche initiale lorsque vous lancez la commande `git init` et c'est la seule raison pour laquelle ce nom est utilisé aussi largement, `origin` est le nom utilisé par défaut pour un dépôt distant lorsque vous lancez `git clone`.
+Si vous lancez à la place `git clone -o booyah`, votre branche de suivi à distance par défaut s'appellera `booyah/master`.(((origin)))
 ====
 
 .Dépôts distant et local après un _clone_
@@ -37,10 +39,10 @@ image::images/remote-branches-2.png[Les travaux locaux et distants peuvent diver
 Lancez la commande `git fetch origin` pour synchroniser vos travaux.
 Cette commande recherche le serveur hébergeant `origin` (dans notre cas, `git.notresociete.com`), y récupère toutes les nouvelles données et met à jour votre base de donnée locale en déplaçant votre pointeur `origin/master` vers une nouvelle position, plus à jour.
 
-.`git fetch` met à jour vos références distantes
-image::images/remote-branches-3.png[`git fetch` met à jour vos références distantes.]
+.`git fetch` met à jour vos branches de suivi à distance
+image::images/remote-branches-3.png[`git fetch` met à jour vos branches de suivi à distance.]
 
-Pour démontrer l'usage de multiples serveurs distants et le fonctionnement des branches distantes pour ces projets distants, supposons que vous avez un autre serveur Git interne qui n'est utilisé que par une équipe de développeurs.
+Pour démontrer l'usage de multiples serveurs distants et le fonctionnement des branches de suivi à distance pour ces projets distants, supposons que vous avez un autre serveur Git interne qui n'est utilisé que par une équipe de développeurs.
 Ce serveur se trouve sur `git.equipe1.notresociete.com`.
 Vous pouvez l'ajouter aux références distantes de votre projet en lançant la commande `git remote add` comme nous l'avons décrit au chapitre <<ch02-git-basics#ch02-git-basics>>.
 Nommez ce serveur distant `equipeun` qui sera le raccourci pour l'URL complète.
@@ -49,10 +51,10 @@ Nommez ce serveur distant `equipeun` qui sera le raccourci pour l'URL complète.
 image::images/remote-branches-4.png[Ajout d'un nouveau server en tant que référence distante.]
 
 Maintenant, vous pouvez lancer `git fetch equipeun` pour récupérer l'ensemble des informations du serveur distant `equipeun` que vous ne possédez pas.
-Comme ce serveur contient déjà un sous-ensemble des données du serveur `origin`, Git ne récupère aucune donnée mais initialise une branche distante appelée `equipeun/master` qui pointe sur le même _commit_ que celui vers lequel pointe la branche `master` de `equipeun`.
+Comme ce serveur contient déjà un sous-ensemble des données du serveur `origin`, Git ne récupère aucune donnée mais initialise une branche de suivi à distance appelée `equipeun/master` qui pointe sur le même _commit_ que celui vers lequel pointe la branche `master` de `equipeun`.
 
-.Suivi d'une branche distante `equipeun/master`
-image::images/remote-branches-5.png[Suivi d'une branche distante `equipeun/master`.]
+.Suivi d'une branche de suivi à distance `equipeun/master`
+image::images/remote-branches-5.png[Suivi d'une branche de suivi à distance `equipeun/master`.]
 
 [[s_pushing_branches]]
 === Pousser les branches
@@ -87,14 +89,16 @@ Si vous ne souhaitez pas l'appeler `correctionserveur` sur le serveur distant, v
 [NOTE]
 .Ne renseignez pas votre mot de passe à chaque fois
 ====
-Si vous utilisez une URL en HTTPS, le serveur Git vous demandera votre nom d'utilisateur et votre mot de passe pour vous authentifier. Par défaut, vous devez entrer ces informations sur votre terminal et le serveur pourra alors déterminer si vous être autorisé à pousser.
+Si vous utilisez une URL en HTTPS, le serveur Git vous demandera votre nom d'utilisateur et votre mot de passe pour vous authentifier.
+Par défaut, vous devez entrer ces informations sur votre terminal et le serveur pourra alors déterminer si vous être autorisé à pousser.
 
-Si vous ne voulez pas entrer ces informations à chaque fois que vous poussez, vous pouvez mettre en place un "cache d'identification" (_credential cache_). Son fonctionnement le plus simple consiste à garder ces informations en mémoire pour quelques minutes mais vous pouvez configurer ce délai en lançant la commande `git config --global credential.helper cache`.
+Si vous ne voulez pas entrer ces informations à chaque fois que vous poussez, vous pouvez mettre en place un "cache d'identification" (_credential cache_).
+Son fonctionnement le plus simple consiste à garder ces informations en mémoire pour quelques minutes mais vous pouvez configurer ce délai en lançant la commande `git config --global credential.helper cache`.
 
 Pour davantage d'informations sur les différentes options de cache d'identification disponibles, vous pouvez vous référer au chapitre <<ch07-git-tools#s_credential_caching>>.
 ====
 
-La prochaine fois qu'un de vos collègues récupère les données depuis le serveur, il récupérera, au sein de la branche distante `origin/correctionserveur`, une référence vers l'état de la branche `correctionserveur` sur le serveur :
+La prochaine fois qu'un de vos collègues récupère les données depuis le serveur, il récupérera, au sein de la branche de suivi à distance `origin/correctionserveur`, une référence vers l'état de la branche `correctionserveur` sur le serveur :
 
 [source,console]
 ----
@@ -165,10 +169,12 @@ Branch correctionserveur set up to track remote branch correctionserveur from or
 [NOTE]
 .Raccourci vers _upstream_
 ====
-Quand vous avez une branche de suivi configurée, vous pouvez faire référence à sa branche amont grâce au raccourci `@{upstream}` ou `@{u}`. Ainsi, si vous êtes sur la branche `master` et sa branche de suivi `origin/master`, vous pouvez utiliser quelque chose comme `git merge @{u}` au lieu de `git merge origin/master` si vous le souhaitez.(((+++@{u}+++)))(((+++@{upstream}+++)))
+Quand vous avez une branche de suivi configurée, vous pouvez faire référence à sa branche amont grâce au raccourci `@{upstream}` ou `@{u}`.
+Ainsi, si vous êtes sur la branche `master` qui suit `origin/master`, vous pouvez utiliser quelque chose comme `git merge @{u}` au lieu de `git merge origin/master` si vous le souhaitez.(((+++@{u}+++)))(((+++@{upstream}+++)))
 ====
 
-Si vous voulez voir quelles branches de suivi vous avez configurées, vous pouvez passer l'option `-vv` à `git branch`. Celle-ci va lister l'ensemble de vos branches locales avec quelques informations supplémentaires, y compris quelle est la branche suivie et si votre branche locale est devant, derrière ou les deux à la fois.
+Si vous voulez voir quelles branches de suivi vous avez configurées, vous pouvez passer l'option `-vv` à `git branch`.
+Celle-ci va lister l'ensemble de vos branches locales avec quelques informations supplémentaires, y compris quelle est la branche suivie et si votre branche locale est devant, derrière ou les deux à la fois.
 
 [source,console]
 ----
@@ -178,9 +184,15 @@ $ git branch -vv
 * correctionserveur f8674d9 [equipe1/correction-serveur-ok: ahead 3, behind 1] this should do it
   test   5ea463a trying something new
 ----
-Vous pouvez constater ici que votre branche `iss53` suit `origin/iss53` et est _"devant de deux"_, ce qui signifie qu'il existe deux _commits_ locaux qui n'ont pas été poussés au serveur. On peut aussi voir que la branche `master` suit `origin/master` et est à jour. On peut voir ensuite que notre branche `correctionserveur` suit la branche `correction-serveur-ok` sur notre serveur `equipe1` et est _"devant de trois"_ et _"derrière de un"_, ce qui signifie qu'il existe un _commit_ qui n'a pas été encore intégré localement et trois _commits_ locaux qui n'ont pas été poussés. Finalement, on peut voir que notre branche `test` ne suit aucune branche distante.
+Vous pouvez constater ici que votre branche `iss53` suit `origin/iss53` et est _"devant de deux"_, ce qui signifie qu'il existe deux _commits_ locaux qui n'ont pas été poussés au serveur.
+On peut aussi voir que la branche `master` suit `origin/master` et est à jour.
+On peut voir ensuite que notre branche `correctionserveur` suit la branche `correction-serveur-ok` sur notre serveur `equipe1` et est _"devant de trois"_ et _"derrière de un"_, ce qui signifie qu'il existe un _commit_ qui n'a pas été encore intégré localement et trois _commits_ locaux qui n'ont pas été poussés.
+Finalement, on peut voir que notre branche `test` ne suit aucune branche distante.
 
-Il est important de noter que ces nombres se basent uniquement sur l'état de votre branche distante la dernière fois qu'elle a été synchronisée depuis le serveur. Cette commande n'effectue aucune recherche sur les serveurs et ne travaille que sur les données locales qui ont été mises en cache depuis ces serveurs. Si vous voulez mettre complètement à jour ces nombres, vous devez préalablement synchroniser (_fetch_) toutes vos branches distantes depuis les serveurs. Vous pouvez le faire de cette façon : `$ git fetch --all; git branch -vv`.
+Il est important de noter que ces nombres se basent uniquement sur l'état de votre branche distante la dernière fois qu'elle a été synchronisée depuis le serveur.
+Cette commande n'effectue aucune recherche sur les serveurs et ne travaille que sur les données locales qui ont été mises en cache depuis ces serveurs.
+Si vous voulez mettre complètement à jour ces nombres, vous devez préalablement synchroniser (_fetch_) toutes vos branches distantes depuis les serveurs.
+Vous pouvez le faire de cette façon : `$ git fetch --all; git branch -vv`.
 
 === Tirer une branche (_Pulling_)
 
@@ -196,7 +208,7 @@ Il est généralement préférable de simplement utiliser les commandes `fetch` 
 === Suppression de branches distantes
 
 (((branches, suppression distante)))
-Supposons que vous en avez terminé avec une branche distante - disons que vous et vos collaborateurs avez terminé une fonctionnalité et l'avez fusionnée dans la branche `master` du serveur distant (ou la branche correspondant à votre code stable).
+Supposons que vous en avez terminé avec une branche distante ‒ disons que vous et vos collaborateurs avez terminé une fonctionnalité et l'avez fusionnée dans la branche `master` du serveur distant (ou la branche correspondant à votre code stable).
 Vous pouvez effacer une branche distante en ajoutant l'option `--delete` à `git push`.
 Si vous souhaitez effacer votre branche `correctionserveur` du serveur, vous pouvez lancer ceci :
 
@@ -207,4 +219,6 @@ To https://github.com/schacon/simplegit
  - [deleted]         correctionserveur
 ----
 
-En résumé, cela ne fait que supprimer le pointeur sur le serveur. Le serveur Git garde généralement les données pour un temps jusqu'à ce qu'un processus de nettoyage (_garbage collection_) passe. De cette manière, si une suppression accidentelle a eu lieu, les données sont souvent très facilement récupérables.
+En résumé, cela ne fait que supprimer le pointeur sur le serveur.
+Le serveur Git garde généralement les données pour un temps jusqu'à ce qu'un processus de nettoyage (_garbage collection_) passe.
+De cette manière, si une suppression accidentelle a eu lieu, les données sont souvent très facilement récupérables.

--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -47,8 +47,8 @@ Ce serveur se trouve sur `git.equipe1.notresociete.com`.
 Vous pouvez l'ajouter aux références distantes de votre projet en lançant la commande `git remote add` comme nous l'avons décrit au chapitre <<ch02-git-basics#ch02-git-basics>>.
 Nommez ce serveur distant `equipeun` qui sera le raccourci pour l'URL complète.
 
-.Ajout d'un nouveau server en tant que référence distante
-image::images/remote-branches-4.png[Ajout d'un nouveau server en tant que référence distante.]
+.Ajout d'un nouveau serveur en tant que référence distante
+image::images/remote-branches-4.png[Ajout d'un nouveau serveur en tant que référence distante.]
 
 Maintenant, vous pouvez lancer `git fetch equipeun` pour récupérer l'ensemble des informations du serveur distant `equipeun` que vous ne possédez pas.
 Comme ce serveur contient déjà un sous-ensemble des données du serveur `origin`, Git ne récupère aucune donnée mais initialise une branche de suivi à distance appelée `equipeun/master` qui pointe sur le même _commit_ que celui vers lequel pointe la branche `master` de `equipeun`.


### PR DESCRIPTION
Le terme "branche distante" était systématiquement utilisé à la place de "branche de suivi à distance".
J'ai corrigé cela en gardant "branche distante" là où il était question de la branche correspondante sur un dépôt distant.
Parmi les autres corrections :
- retour à la ligne pour chaque phrase
- reformulation à la ligne 11
- remplacement de "server" (non traduit) par "serveur"