### PR TITLE
Branche de suivi à distance `equipeun/master`

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -53,8 +53,8 @@ image::images/remote-branches-4.png[Ajout d'un nouveau serveur en tant que réf�
 Maintenant, vous pouvez lancer `git fetch equipeun` pour récupérer l'ensemble des informations du serveur distant `equipeun` que vous ne possédez pas.
 Comme ce serveur contient déjà un sous-ensemble des données du serveur `origin`, Git ne récupère aucune donnée mais initialise une branche de suivi à distance appelée `equipeun/master` qui pointe sur le même _commit_ que celui vers lequel pointe la branche `master` de `equipeun`.
 
-.Suivi d'une branche de suivi à distance `equipeun/master`
-image::images/remote-branches-5.png[Suivi d'une branche de suivi à distance `equipeun/master`.]
+.Branche de suivi à distance `equipeun/master`
+image::images/remote-branches-5.png[Branche de suivi à distance `equipeun/master`.]
 
 [[s_pushing_branches]]
 === Pousser les branches


### PR DESCRIPTION
supprimé le mot "suivi" en double