### PR TITLE
Add missing quotes

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -36,7 +36,7 @@ Voici un exemple de configuration de l'option « store » avec un nom de fichi
 
 [source,console]
 ----
-$ git config --global credential.helper store --file ~/.my-credentials
+$ git config --global credential.helper 'store --file ~/.my-credentials'
 ----
 
 Git vous permet même de configurer plusieurs assistants.


### PR DESCRIPTION
The command need a pair of single quotes as in the EN edition: https://github.com/progit/progit2/blob/master/book/07-git-tools/sections/credentials.asc