### PR TITLE
Fix typo: branch name not in sync with the diagram

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -26,7 +26,7 @@ Dans cet exemple, vous lanceriez les commandes suivantes :
 
 [source,console]
 ----
-$ git checkout experience
+$ git checkout experiment
 $ git rebase master
 First, rewinding head to replay your work on top of it...
 Applying: added staged command
@@ -57,24 +57,24 @@ Rebaser rejoue les modifications d'une ligne de _commits_ sur une autre dans l'o
 
 Vous pouvez aussi faire rejouer votre rebasage sur autre chose qu'une branche.
 Prenez un historique tel que <<ch03-git-branching#rbdiag_e>> par exemple.
-Vous avez créé une branche thématique (`serveur`) pour ajouter des fonctionnalités côté serveur à votre projet et avez réalisé un _commit_.
+Vous avez créé une branche thématique (`server`) pour ajouter des fonctionnalités côté serveur à votre projet et avez réalisé un _commit_.
 Ensuite, vous avez créé une branche pour ajouter des modifications côté client (`client`) et avez validé plusieurs fois.
-Finalement, vous avez rebasculé sur la branche `serveur` et avez réalisé quelques _commits_ supplémentaires.
+Finalement, vous avez rebasculé sur la branche `server` et avez réalisé quelques _commits_ supplémentaires.
 
 
 [[rbdiag_e]]
 .Un historique avec deux branches thématiques qui sortent l'une de l'autre
 image::images/interesting-rebase-1.png[Un historique avec deux branches thématiques qui sortent l'une de l'autre.]
 
-Supposons que vous décidez que vous souhaitez fusionner vos modifications du côté client dans votre ligne principale pour une publication (_release_) mais vous souhaitez retenir les modifications de la partie serveur jusqu'à ce qu'elles soient un peu mieux testées.
+Supposons que vous décidez que vous souhaitez fusionner vos modifications du côté client dans votre ligne principale pour une publication (_release_) mais vous souhaitez retenir les modifications de la partie server jusqu'à ce qu'elles soient un peu mieux testées.
 Vous pouvez récupérer les modifications du côté client qui ne sont pas sur le serveur (`C8` et `C9`) et les rejouer sur la branche `master` en utilisant l'option `--onto` de `git rebase` :
 
 [source,console]
 ----
-$ git rebase --onto master serveur client
+$ git rebase --onto master server client
 ----
 
-Cela signifie en substance "Extraire la branche client, déterminer les patchs depuis l'ancêtre commun des branches `client` et `serveur` puis les rejouer sur `master` ".
+Cela signifie en substance "Extraire la branche client, déterminer les patchs depuis l'ancêtre commun des branches `client` et `server` puis les rejouer sur `master` ".
 C'est assez complexe, mais le résultat est assez impressionnant.
 
 .Rebaser deux branches thématiques l'une sur l'autre
@@ -92,34 +92,34 @@ $ git merge client
 .Avance rapide sur votre branche `master` pour inclure les modifications de la branche client
 image::images/interesting-rebase-3.png[Avance rapide sur votre branche `master` pour inclure les modifications de la branche client.]
 
-Supposons que vous décidiez de tirer (_pull_) votre branche `serveur` aussi.
-Vous pouvez rebaser la branche `serveur` sur la branche `master` sans avoir à l'extraire avant en utilisant `git rebase [branchedebase] [branchethematique]` — qui extrait la branche thématique (dans notre cas, `serveur`) pour vous et la rejoue sur la branche de base (`master`) :
+Supposons que vous décidiez de tirer (_pull_) votre branche `server` aussi.
+Vous pouvez rebaser la branche `server` sur la branche `master` sans avoir à l'extraire avant en utilisant `git rebase [branchedebase] [branchethematique]` — qui extrait la branche thématique (dans notre cas, `server`) pour vous et la rejoue sur la branche de base (`master`) :
 
 [source,console]
 ----
-$ git rebase master serveur
+$ git rebase master server
 ----
 
-Cette commande rejoue les modifications de `serveur` sur le sommet de la branche `master`, comme indiqué dans <<ch03-git-branching#rbdiag_h>>.
+Cette commande rejoue les modifications de `server` sur le sommet de la branche `master`, comme indiqué dans <<ch03-git-branching#rbdiag_h>>.
 
 [[rbdiag_h]]
-.Rebasage de la branche serveur sur le sommet de la branche `master`.
-image::images/interesting-rebase-4.png[Rebasage de la branche serveur sur le sommet de la branche `master`.]
+.Rebasage de la branche server sur le sommet de la branche `master`.
+image::images/interesting-rebase-4.png[Rebasage de la branche server sur le sommet de la branche `master`.]
 
 Vous pouvez ensuite faire une avance rapide sur la branche de base (`master`) :
 
 [source,console]
 ----
 $ git checkout master
-$ git merge serveur
+$ git merge server
 ----
 
-Vous pouvez effacer les branches `client` et `serveur` une fois que tout le travail est intégré et que vous n'en avez plus besoin, éliminant tout l'historique de ce processus, comme visible sur <<ch03-git-branching#rbdiag_i>> :
+Vous pouvez effacer les branches `client` et `server` une fois que tout le travail est intégré et que vous n'en avez plus besoin, éliminant tout l'historique de ce processus, comme visible sur <<ch03-git-branching#rbdiag_i>> :
 
 [source,console]
 ----
 $ git branch -d client
-$ git branch -d serveur
+$ git branch -d server
 ----
 
 [[rbdiag_i]]


### PR DESCRIPTION
The branch names in the french version ('experience`, `server`) is not in sync with the ones in the diagrams (`experiment`, `server`).
I suggest to either use the same as in the diagram (which I did in this page for now) either update the diagrams so that they use the same branch name (`experience`, `serveur`).

Let me know your thoughts.