### PR TITLE
Remplace populer par alimenter.

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -131,7 +131,7 @@ image::images/reset-ex6.png[]
 Maintenant, `git status` n'indique plus rien, car les trois arborescences sont à nouveau identiques.
 
 Les basculements de branches ou les clonages déroulent le même processus.
-Quand vous extrayez une branche, cela change *HEAD* pour pointer sur la nouvelle référence de branche, popule votre *index* avec l'instantané de ce _commit_, puis copie le contenu de l'index dans votre *répertoire de travail*.
+Quand vous extrayez une branche, cela change *HEAD* pour pointer sur la nouvelle référence de branche, alimente votre *index* avec l'instantané de ce _commit_, puis copie le contenu de l'index dans votre *répertoire de travail*.
 
 === Le rôle de reset
 

--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -814,7 +814,7 @@ aucune modification ajoutée à la validation mais des fichiers non suivis sont 
 ----
 
 Supprimer le répertoire n'est pas difficile, mais sa présence est assez déroutante.
-Si vous le supprimez puis que vous rebasculez sur la branche qui contient le sous-module, vous devrez lancer `submodule update --init` pour le repopuler.
+Si vous le supprimez puis que vous rebasculez sur la branche qui contient le sous-module, vous devrez lancer `submodule update --init` pour le réalimenter.
 
 [source,console]
 ----


### PR DESCRIPTION
populer n'existe pas en français

popule => alimente
repopuler => réalimenter

J'ai préféré alimenter à peupler. 