### PR TITLE
au → dans

### DIFF
--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -131,7 +131,7 @@ Il contient un étiqueteur, une date, un message et un pointeur.
 La principale différence est que l'étiquette pointe en général vers un _commit_ plutôt qu'un arbre.
 C'est comme une référence à une branche, mais elle ne bouge jamais : elle pointe toujours vers le même _commit_, lui donnant un nom plus sympathique.
 
-Comme présenté au <<ch02-git-basics-chapter#ch02-git-basics-chapter>>, il existe deux types d'étiquettes : annotée et légère.
+Comme présenté dans <<ch02-git-basics-chapter#ch02-git-basics-chapter>>, il existe deux types d'étiquettes : annotée et légère.
 Vous pouvez créer une étiquette légère comme ceci :
 
 [source,console]


### PR DESCRIPTION
la sortie PDF est "Comme présenté au Les bases de Git" et pas "Comme présenté au chapitre Les bases de Git". Il est préférable d'avoir "dans" ici dans ce contexte.